### PR TITLE
feat(dui validation): allows DUI value to optionally contain hyphen

### DIFF
--- a/src/lib/__tests__/documents.test.ts
+++ b/src/lib/__tests__/documents.test.ts
@@ -7,13 +7,21 @@ describe('documents', () => {
     cases = [
       ['', false],
       ['00000000-0', false],
+      ['000000000', false],
       ['12345678-9', false],
+      ['123456789', false],
       ['00016297-5', true],
+      ['000162975', true],
       ['02495046-3', true],
+      ['024950463', true],
       ['04288874-5', true],
+      ['042888745', true],
       ['03766021-3', true],
+      ['037660213', true],
       ['05149147-4', true],
+      ['051491474', true],
       ['05149149-0', true],
+      ['051491490', true],
     ];
     test.each(cases)('given %s should return %s', (arg, expected) => {
       const result = isDUI(arg);

--- a/src/lib/documents.ts
+++ b/src/lib/documents.ts
@@ -1,7 +1,7 @@
 import { isMunicipalityCode } from './municipalities';
 import { isDate } from './utils';
 
-export const duiRegExp = /(^\d{8})-(\d$)/;
+export const duiRegExp = /(^\d{8})-?(\d$)/;
 export const nitRegExp = /(^\d{4})-(\d{6})-(\d{3})-(\d$)/;
 
 /**
@@ -11,13 +11,18 @@ export const nitRegExp = /(^\d{4})-(\d{6})-(\d{3})-(\d$)/;
  * @returns {boolean}         Validity of the given DUI
  */
 export function isDUI(str: string): boolean {
-  if (!duiRegExp.test(str)) return false;
+  const [duiValue, digitsSection, verifier] = str.match(duiRegExp) ?? [];
+  if (!duiValue) return false;
 
-  let sum = 0;
-  const [digits, verifier] = str.split('-');
-  for (let i = 0; i < digits.length; i++) {
-    sum += Number(digits[i]) * (digits.length + 1 - i);
-  }
+  const digits = digitsSection.split('');
+
+  const [sum] = digits.reduce(
+    ([total, position], digit) => [
+      total + Number(digit) * position,
+      position - 1,
+    ],
+    [0, 9]
+  );
 
   return Number(verifier) === (10 - (sum % 10)) % 10 && sum > 0;
 }


### PR DESCRIPTION
This change allows for the hyphen in the DUI value to be optional, this two examples are valid:
```ts
import { isDUI } from 'sivar-utils'

const validDUI = isDUI('02495046-3')
const alsoValidDUI = isDUI('024950463')
```

Additionally I simplified the iteration logic of the digits, to make it a little more transparent on what is happening.